### PR TITLE
112 implement ITextNormalizer in QueryStringTokenizer

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
@@ -1,4 +1,5 @@
-﻿using LTU.SearchEngine.Backend.Core.Enums;
+﻿using LTU.SearchEngine.Backend.Core;
+using LTU.SearchEngine.Backend.Core.Enums;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -12,12 +13,15 @@ namespace LTU.SearchEngine.Application.QueryParsing.Helpers;
 public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, QueryTokenType>
 {
 	private readonly IQuerySyntaxHelper _syntaxHelper;
+    private readonly ITextNormalizer<string> _normalizer;
 
-	public QueryStringTokenizer(IQuerySyntaxHelper syntaxHelper)
+    public QueryStringTokenizer(IQuerySyntaxHelper syntaxHelper, ITextNormalizer<string> normalizer)
 	{
 		_syntaxHelper = syntaxHelper ?? 
 			throw new ArgumentNullException(nameof(syntaxHelper));
-	}
+        _normalizer = normalizer ?? 
+			throw new ArgumentNullException(nameof(normalizer));
+    }
 
 	// Finalizes a token build
 	/// <inheritdoc/>
@@ -28,10 +32,24 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, QueryT
 	{
 		if (stringBuilder.Length == 0) return;
 
-		var token = stringBuilder.ToString().Trim();
-		var extractedToken = new ExtractedQueryToken(queryTokenType, token);
 
-		if (token.Length > 0)
+		var token = stringBuilder.ToString().Trim();
+        var extractedToken = new ExtractedQueryToken(queryTokenType, token);
+
+        // Normalize BEFORE creating ExtractedQueryToken
+        if (queryTokenType == QueryTokenType.Term ||
+		queryTokenType == QueryTokenType.Phrase)
+			{
+				token = _normalizer.Normalize(token);
+
+				if (token == null)
+				{
+					stringBuilder.Clear();
+					return;
+				}
+			}
+
+        if (token.Length > 0)
 			tokens.Add(extractedToken);
 
 		stringBuilder.Clear();

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
@@ -38,16 +38,16 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, QueryT
 
         // Normalize BEFORE creating ExtractedQueryToken
         if (queryTokenType == QueryTokenType.Term ||
-		queryTokenType == QueryTokenType.Phrase)
-			{
-				token = _normalizer.Normalize(token);
+			queryTokenType == QueryTokenType.Phrase)
+		{
+			token = _normalizer.Normalize(token);
 
-				if (token == null)
-				{
-					stringBuilder.Clear();
-					return;
-				}
+			if (token == null)
+			{
+				stringBuilder.Clear();
+				return;
 			}
+		}
 
         if (token.Length > 0)
 			tokens.Add(extractedToken);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
@@ -1,10 +1,12 @@
 ﻿using LTU.SearchEngine.Application.QueryParsing.Helpers;
+using LTU.SearchEngine.Backend.Core;
 using LTU.SearchEngine.Backend.Core.Enums;
 using LTU.SearchEngine.Backend.Core.Exceptions;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using Moq;
 using System;
 using System.Text;
+using Xunit;
 
 namespace LTU.SearchEngine.Test.QueryParsing.Tests;
 
@@ -12,19 +14,28 @@ public class QueryTokenizerTests
 {
 	private readonly QueryStringTokenizer _sut;
 	private readonly Mock<IQuerySyntaxHelper> _mockSyntaxHelper;
+	private readonly Mock<ITextNormalizer<string>> _mockNormalizer;
 
 	public QueryTokenizerTests()
 	{
 		_mockSyntaxHelper = new Mock<IQuerySyntaxHelper>();
-		_sut = new QueryStringTokenizer(_mockSyntaxHelper.Object);
-	}
+		_mockNormalizer = new Mock<ITextNormalizer<string>>();
+		_sut = new QueryStringTokenizer(_mockSyntaxHelper.Object, _mockNormalizer.Object);
+
+        _mockNormalizer
+            .Setup(n => n.Normalize(It.IsAny<string>()))
+            .Returns((string s) => s);
+    }
 
 	[Fact]
 	public void Constructor_NullIQuerySyntaxHelper_ShouldThrowArgumentNullException()
 	{
-		// Act & Assert 
-		Assert.Throws<ArgumentNullException>(() => new QueryStringTokenizer(null!));
-	}
+        // Act & Assert 
+        Assert.Throws<ArgumentNullException>(() =>
+		new QueryStringTokenizer(
+        new Mock<IQuerySyntaxHelper>().Object,
+        null!));
+    }
 
 	[Fact]
 	public void Tokenize_ValidateGroupThrowsInvalidQueryStringException_ShouldPropagate()
@@ -228,5 +239,36 @@ public class QueryTokenizerTests
 		Assert.Equivalent(token, tokens[0]);
 		Assert.Equal(0, sb.Length);
 	}
+
+    [Fact]
+    public void Tokenize_Should_Call_Normalizer_For_Term()
+    {
+        _mockNormalizer
+            .Setup(n => n.Normalize(It.IsAny<string>()))
+            .Returns((string s) => s);
+
+        _sut.Tokenize("Running");
+
+        _mockNormalizer.Verify(
+            n => n.Normalize("Running"),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData("AND")]
+    [InlineData("OR")]
+    [InlineData("NOT")]
+    public void Tokenize_Should_Not_Normalize_LogicalOperators(string input)
+    {
+        
+        var result = _sut.Tokenize(input);
+
+        Assert.Single(result);
+        Assert.Equal(QueryTokenType.LogicalOperator, result[0].TokenType);
+
+        _mockNormalizer.Verify(
+            n => n.Normalize(It.IsAny<string>()),
+            Times.Never);
+    }
 }
 


### PR DESCRIPTION
- Inject ITextNormalizer<string>
- Normalize term or phrase before creating ExtractedQueryToken
- Skip normalization for logical and grouping operators
- Add interaction tests for normalization