### PR TITLE
109 implement the i queryparser class

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/Program.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/Program.cs
@@ -1,6 +1,11 @@
 using LTU.SearchEngine.Application;
+using LTU.SearchEngine.Application.QueryParsing;
+using LTU.SearchEngine.Application.QueryParsing.Helpers;
 using LTU.SearchEngine.Backend.Core;
+using LTU.SearchEngine.Backend.Core.Enums;
 using LTU.SearchEngine.Backend.Core.Model;
+using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
 using LTU.SearchEngine.Backend.Core.TextNormalization;
 using LTU.SearchEngine.BackgroundServices;
 using LTU.SearchEngine.Infrastructure;
@@ -63,14 +68,33 @@ public class Program
         builder.Services.AddTransient<ICrawler, Crawler>();
         builder.Services.AddTransient<IIndexer, Indexer>();
 
-        // ========================================================================
-        // 4. Application Logic (Use Cases)
-        // ========================================================================
-        // The main unit of work: Orchestrates Crawling -> Validating -> Indexing for a single job.
-        builder.Services.AddTransient<IProcessCrawlJobUseCase, ProcessCrawlJobUseCase>();
+
+		// ========================================================================
+		// 4. Search & Query Logic (Core)
+		// ========================================================================
+		// Tokenizer and TreeBuilder used by the Parser to transform strings into ASTs.
+		builder.Services.AddTransient<
+            IStringTokenizer<ExtractedQueryToken, QueryTokenType>, 
+            QueryStringTokenizer>();
+		
+        builder.Services.AddTransient<
+            ITreeBuilder<HashSet<int>, ExtractedQueryToken>, 
+            AbstractSyntaxTreeBuilder<HashSet<int>>>();
+
+		// The Parser that orchestrates the transformation.
+		builder.Services.AddTransient<IQueryParser, QueryParser>();
+
+		// Visitor that evaluates the resulting tree against the database.
+		builder.Services.AddTransient<IQueryVisitor<HashSet<int>>, QueryEvaluatorVisitor>();
+
+		// ========================================================================
+		// 5. Application Logic (Use Cases)
+		// ========================================================================
+		// The main unit of work: Orchestrates Crawling -> Validating -> Indexing for a single job.
+		builder.Services.AddTransient<IProcessCrawlJobUseCase, ProcessCrawlJobUseCase>();
 
         // ========================================================================
-        // 5. Background Services & TPL Engine
+        // 6. Background Services & TPL Engine
         // ========================================================================
         // The Dispatcher manages the TPL Dataflow pipeline (Queue).
         builder.Services.AddSingleton<ICrawlJobDispatcher, TplCrawlJobDispatcher>();
@@ -79,7 +103,7 @@ public class Program
         builder.Services.AddHostedService<CrawlBackgroundService>();
 
         // ========================================================================
-        // 6. API & Presentation
+        // 7. API & Presentation
         // ========================================================================
         builder.Services.AddControllers();
         builder.Services.AddOpenApi();

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/Program.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/Program.cs
@@ -69,10 +69,12 @@ public class Program
         builder.Services.AddTransient<IIndexer, Indexer>();
 
 
-		// ========================================================================
-		// 4. Search & Query Logic (Core)
-		// ========================================================================
-		// Tokenizer and TreeBuilder used by the Parser to transform strings into ASTs.
+        // ========================================================================
+        // 4. Search & Query Logic (Core)
+        // ========================================================================
+        // Tokenizer and TreeBuilder used by the Parser to transform strings into ASTs.
+        builder.Services.AddTransient<IQuerySyntaxHelper, QuerySyntaxHelper>();
+
 		builder.Services.AddTransient<
             IStringTokenizer<ExtractedQueryToken, QueryTokenType>, 
             QueryStringTokenizer>();
@@ -80,6 +82,10 @@ public class Program
         builder.Services.AddTransient<
             ITreeBuilder<HashSet<int>, ExtractedQueryToken>, 
             AbstractSyntaxTreeBuilder<HashSet<int>>>();
+
+        builder.Services.AddTransient<
+            IShuntingYardParser<ExtractedQueryToken>, 
+            SearchQueryShuntingYardParser>();
 
 		// The Parser that orchestrates the transformation.
 		builder.Services.AddTransient<IQueryParser, QueryParser>();

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/IQueryParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/IQueryParser.cs
@@ -1,0 +1,9 @@
+﻿using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
+
+namespace LTU.SearchEngine.Application.QueryParsing
+{
+	public interface IQueryParser
+	{
+		QueryNode<HashSet<int>> Parse(string rawQuery);
+	}
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryParser.cs
@@ -1,0 +1,33 @@
+﻿using LTU.SearchEngine.Application.QueryParsing.Helpers;
+using LTU.SearchEngine.Backend.Core.Enums;
+using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
+using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
+
+namespace LTU.SearchEngine.Application.QueryParsing;
+
+public class QueryParser : IQueryParser
+{
+	private readonly ITreeBuilder<HashSet<int>, ExtractedQueryToken> _treeBuilder;
+	private readonly IStringTokenizer<ExtractedQueryToken, QueryTokenType> _stringTokenizer;
+
+	public QueryParser(
+		ITreeBuilder<HashSet<int>, ExtractedQueryToken> treeBuilder,
+		IStringTokenizer<ExtractedQueryToken, QueryTokenType> stringTokenizer
+		)
+	{
+		_treeBuilder = treeBuilder ??
+			throw new ArgumentNullException("Tree builder cannot be null.", nameof(treeBuilder));
+
+		_stringTokenizer = stringTokenizer ??
+			throw new ArgumentNullException("String tokenizer cannot be null.", nameof(stringTokenizer));
+	}
+
+	public QueryNode<HashSet<int>> Parse(string rawQuery)
+	{
+		List<ExtractedQueryToken> tokens = _stringTokenizer.Tokenize(rawQuery);
+		QueryNode<HashSet<int>> rootNode = _treeBuilder.BuildTree(tokens);
+
+		return rootNode;
+	}
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryParserTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryParserTests.cs
@@ -1,0 +1,109 @@
+﻿using LTU.SearchEngine.Application.QueryParsing;
+using LTU.SearchEngine.Application.QueryParsing.Helpers;
+using LTU.SearchEngine.Backend.Core.Enums;
+using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
+using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
+using Moq;
+
+namespace LTU.SearchEngine.Test.Application.Tests;
+
+public class QueryParserTests
+{
+	private readonly Mock<ITreeBuilder<HashSet<int>, ExtractedQueryToken>> _treeBuilderMock;
+	private readonly Mock<IStringTokenizer<ExtractedQueryToken, QueryTokenType>> _tokenizerMock;
+
+	private readonly QueryParser _parser;
+
+	public QueryParserTests()
+	{
+		_treeBuilderMock = 
+			new Mock<ITreeBuilder<HashSet<int>, ExtractedQueryToken>>();
+		_tokenizerMock = 
+			new Mock<IStringTokenizer<ExtractedQueryToken, QueryTokenType>>();
+
+		_parser = new QueryParser(_treeBuilderMock.Object, _tokenizerMock.Object);
+	}
+
+	[Fact]
+	public void Constructor_NullTreeBuilder_ShouldThrowArgumentNullException()
+	{
+		Assert.Throws<ArgumentNullException>(() =>
+			new QueryParser(null!, _tokenizerMock.Object));
+	}
+
+	[Fact]
+	public void Constructor_NullTokenizer_ShouldThrowArgumentNullException()
+	{
+		Assert.Throws<ArgumentNullException>(() =>
+			new QueryParser(_treeBuilderMock.Object, null!));
+	}
+
+	[Fact]
+	public void Parse_ShouldTokenizeQuery()
+	{
+		// Arrange
+		string query = "cat AND dog";
+		var tokens = new List<ExtractedQueryToken>();
+
+		_tokenizerMock
+			.Setup(t => t.Tokenize(query))
+			.Returns(tokens);
+
+		_treeBuilderMock
+			.Setup(t => t.BuildTree(tokens))
+			.Returns(Mock.Of<QueryNode<HashSet<int>>>());
+
+		// Act
+		_parser.Parse(query);
+
+		// Assert
+		_tokenizerMock.Verify(t => t.Tokenize(query), Times.Once);
+	}
+
+	[Fact]
+	public void Parse_ShouldPassTokensToTreeBuilder()
+	{
+		// Arrange
+		string query = "cat";
+		var tokens = new List<ExtractedQueryToken>();
+
+		_tokenizerMock
+			.Setup(t => t.Tokenize(query))
+			.Returns(tokens);
+
+		_treeBuilderMock
+			.Setup(t => t.BuildTree(tokens))
+			.Returns(Mock.Of<QueryNode<HashSet<int>>>());
+
+		// Act
+		_parser.Parse(query);
+
+		// Assert
+		_treeBuilderMock.Verify(t => t.BuildTree(tokens), Times.Once);
+	}
+
+	[Fact]
+	public void Parse_ShouldReturnRootNodeFromTreeBuilder()
+	{
+		// Arrange
+		string query = "cat";
+		var tokens = new List<ExtractedQueryToken>();
+
+		var expectedNode = Mock.Of<QueryNode<HashSet<int>>>();
+
+		_tokenizerMock
+			.Setup(t => t.Tokenize(query))
+			.Returns(tokens);
+
+		_treeBuilderMock
+			.Setup(t => t.BuildTree(tokens))
+			.Returns(expectedNode);
+
+		// Act
+		var result = _parser.Parse(query);
+
+		// Assert
+		Assert.Equal(expectedNode, result);
+	}
+}


### PR DESCRIPTION
I know that it said that `QueryParser` should orchestrate `QueryEvaluator` as well. However, this was written before some changes were made to the visitor design.

As such, `QueryParser` only `orchestrates`, `ITreeBuilder`, and `IStringTokenizer`.
One thing of note to mention is that I have added all the needed classes in the DI related to the `QueryParser` class.   